### PR TITLE
UX: Added new keyboard mode - KeyboardMarkup

### DIFF
--- a/Telegram.Bot.GLObot.Notifier.Webhook/Commands/KeyboardMarkupCommand.cs
+++ b/Telegram.Bot.GLObot.Notifier.Webhook/Commands/KeyboardMarkupCommand.cs
@@ -1,0 +1,53 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Serilog;
+using Telegram.Bot.Framework.Abstractions;
+using Telegram.Bot.Library.Keyboard;
+using Telegram.Bot.Library.Services;
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.InlineKeyboardButtons;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Telegram.Bot.GLObot.Notifier.Webhook.Commands
+{
+    internal class KeyboardMarkupCommand : TokenSensitiveCommand
+    {
+        private readonly IEmployeesRegistry _employeesRegistry;
+        private readonly ILogger _logger;
+
+        public KeyboardMarkupCommand(IGloOfficeTimeClient officeTimeClient,
+            ILogger logger, IEmployeesRegistry employeesRegistry) : base("keyboard", officeTimeClient)
+        {
+            _logger = logger;
+            _employeesRegistry = employeesRegistry;
+        }
+
+        protected override async Task<UpdateHandlingResult> ExecuteTokenSensitiveInternal(Update update,
+            CommandArgs args)
+        {
+            await ShowKeyboardMarkup(update.Message.Chat.Id, "Choose Employee",
+                _employeesRegistry.GetKeyboardMarkup(update.Message.Chat.Id).ToArray());
+
+            return UpdateHandlingResult.Continue;
+        }
+
+        private async Task<string> ShowKeyboardMarkup(long chatId, string title, KeyboardButton[][] buttons)
+        {
+            _logger.Information("Showing keyboard markup with values {@Keyboard} to chat {ChatId}",
+                buttons.SelectMany(c => c.Select(r => r.Text)), chatId);
+
+            var rkm = new ReplyKeyboardMarkup
+            {
+                Keyboard = buttons
+            };
+
+            await Bot.Client.SendTextMessageAsync(
+                new ChatId(chatId),
+                title,
+                replyMarkup: rkm
+            );
+
+            return null;
+        }
+    }
+}

--- a/Telegram.Bot.GLObot.Notifier.Webhook/Extensions/Extensions.cs
+++ b/Telegram.Bot.GLObot.Notifier.Webhook/Extensions/Extensions.cs
@@ -11,7 +11,7 @@ namespace Telegram.Bot.GLObot.Notifier.Webhook.Extensions
         {
             var direction = checkinDetails.Direction == CheckinDirection.In ? "entering" : "leaving";
             return bot.SendTextMessageAsync(chatId,
-                $"Employee *{name}* was last seen *{direction.ToUpperInvariant()}* _{checkinDetails.Area}_ at *{checkinDetails.Timestamp}*" +
+                $"Employee *{name}* was last seen *{direction.ToUpperInvariant()}* _{checkinDetails.Area}_ at *{checkinDetails.TimeStamp}*" +
                 (checkinStats == null ? "" : $"\nWorking time today *{checkinStats.WorkingTimeToday}*.") +
                 (checkinStats == null ? "" : $"\nTotal time today *{checkinStats.TimeWithTeleports}*.") +
                 (checkinStats?.FirstCheckinToday == null ? "" : $"\nFirst checkin today *{checkinStats.FirstCheckinToday}*"),

--- a/Telegram.Bot.GLObot.Notifier.Webhook/GloBot.cs
+++ b/Telegram.Bot.GLObot.Notifier.Webhook/GloBot.cs
@@ -20,7 +20,7 @@ namespace Telegram.Bot.GLObot.Notifier.Webhook
         public override async Task HandleUnknownUpdate(Update update)
         {
             _logger.Warning("Unable to handle update {@Update}", update);
-            await Client.SendTextMessageAsync(update.Message.Chat.Id, "Unalbe to handle update", ParseMode.Markdown,
+            await Client.SendTextMessageAsync(update.Message.Chat.Id, "Unable to handle update. Try /keyboard or /start.", ParseMode.Markdown,
                 replyToMessageId: update.Message.MessageId);
         }
 

--- a/Telegram.Bot.GLObot.Notifier.Webhook/Startup.cs
+++ b/Telegram.Bot.GLObot.Notifier.Webhook/Startup.cs
@@ -41,6 +41,7 @@ namespace Telegram.Bot.GLObot.Notifier.Webhook
                 .AddUpdateHandler<StartCommand>()
                 .AddUpdateHandler<SetTokenCommand>()
                 .AddUpdateHandler<EmployeeTrackHandler>()
+                .AddUpdateHandler<KeyboardMarkupCommand>()
                 .Configure();
         }
 

--- a/Telegram.Bot.Library/PredefinedEmployees/EmployeesRegistry.cs
+++ b/Telegram.Bot.Library/PredefinedEmployees/EmployeesRegistry.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Telegram.Bot.Library.Keyboard;
 using Telegram.Bot.Library.Services;
+using Telegram.Bot.Types;
 
 namespace Telegram.Bot.Library.PredefinedEmployees
 {
@@ -37,6 +38,28 @@ namespace Telegram.Bot.Library.PredefinedEmployees
                 yield return new KeyboardRow(employeeRow.ToArray());
 
             yield return new KeyboardRow(new[] {PredefinedEmployeesKeyboard.AllKey});
+        }
+
+        public IEnumerable<KeyboardButton[]> GetKeyboardMarkup(long chatId)
+        {
+            if (!_employeeRecords.ContainsKey(chatId))
+                LoadRecords(chatId);
+            
+            var rows = new List<KeyboardButton[]>();
+            var cols = new List<KeyboardButton>();
+            int i =  0;
+            foreach (var employeeRecord in _employeeRecords[chatId])
+            {
+                i++;
+                cols.Add(new KeyboardButton($"#{employeeRecord.EmployeeName}"));
+                if (i % 3 != 0)
+                    continue;
+
+                rows.Add(cols.ToArray());
+                cols = new List<KeyboardButton>();
+            }
+
+            return rows;
         }
 
         public int GetEmployeeId(long chatId, string name)

--- a/Telegram.Bot.Library/Services/IEmployeesRegistry.cs
+++ b/Telegram.Bot.Library/Services/IEmployeesRegistry.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Telegram.Bot.Library.Keyboard;
+using Telegram.Bot.Types;
 
 namespace Telegram.Bot.Library.Services
 {
@@ -9,5 +10,7 @@ namespace Telegram.Bot.Library.Services
         int GetEmployeeId(long chatId, string name);
         string GetEmployeeName(long chatId, int id);
         int[] GetAllEmployeeIds(long chatId);
+        IEnumerable<KeyboardButton[]> GetKeyboardMarkup(long chatId);
+
     }
 }


### PR DESCRIPTION
New keyboard will always be available to send quick commands even after bot restart. Reusing existing handler to process new keyboard commands as keys don't support callback. To use send _/keyboard_ once.